### PR TITLE
Use streams to replace explicit for-loops

### DIFF
--- a/src/main/java/kirkstein/storage/Storage.java
+++ b/src/main/java/kirkstein/storage/Storage.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 
 import kirkstein.task.Deadline;
 import kirkstein.task.Event;
@@ -36,11 +37,12 @@ public class Storage {
      */
     public void saveTask(ArrayList<Task> tasks) {
         try (FileWriter writer = new FileWriter(filePath)) {
-            for (Task task : tasks) {
-                writer.write(task.toString() + "\n");
-            }
+            String content = tasks.stream()
+                    .map(task -> task.toString() + "\n")
+                    .collect(Collectors.joining());
+            writer.write(content);
         } catch (IOException e) {
-            // Fail silently if unable to save tasks
+            System.err.println("Warning: Failed to save tasks - " + e.getMessage());
         }
     }
 

--- a/src/main/java/kirkstein/tasklist/TaskList.java
+++ b/src/main/java/kirkstein/tasklist/TaskList.java
@@ -1,6 +1,7 @@
 package kirkstein.tasklist;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import kirkstein.task.Task;
 
@@ -92,12 +93,9 @@ public class TaskList {
      * @return ArrayList of tasks that match the keyword.
      */
     public ArrayList<Task> findTask(String searchTerm) {
-        ArrayList<Task> result = new ArrayList<>();
-        for (Task task : list) {
-            if (task.getDescription().toLowerCase().contains(searchTerm.toLowerCase())) {
-                result.add(task);
-            }
-        }
-        return result;
+        return list.stream()
+                .filter(task -> task.getDescription().toLowerCase()
+                        .contains(searchTerm.toLowerCase()))
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/src/main/java/kirkstein/ui/Ui.java
+++ b/src/main/java/kirkstein/ui/Ui.java
@@ -1,6 +1,8 @@
 package kirkstein.ui;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import kirkstein.task.Task;
 
@@ -37,12 +39,10 @@ public class Ui {
      * @return Formatted task list string
      */
     public String showTaskList(ArrayList<Task> tasks) {
-        StringBuilder result = new StringBuilder();
-        result.append("Here are your Epstein files:\n");
-        for (int i = 0; i < tasks.size(); i++) {
-            result.append((i + 1)).append(".").append(tasks.get(i).toString()).append("\n");
-        }
-        return result.toString();
+        String taskLines = IntStream.range(0, tasks.size())
+                .mapToObj(i -> (i + 1) + "." + tasks.get(i).toString() + "\n")
+                .collect(Collectors.joining());
+        return "Here are your Epstein files:\n" + taskLines;
     }
 
     /**
@@ -110,15 +110,12 @@ public class Ui {
      * @return Formatted search results string
      */
     public String showFindResults(ArrayList<Task> tasks) {
-        StringBuilder result = new StringBuilder();
         if (tasks.isEmpty()) {
-            result.append("No matching tasks found in your Epstein files.\n");
-        } else {
-            result.append("Here are your searched Epstein files:\n");
-            for (int i = 0; i < tasks.size(); i++) {
-                result.append((i + 1)).append(".").append(tasks.get(i).toString()).append("\n");
-            }
+            return "No matching tasks found in your Epstein files.\n";
         }
-        return result.toString();
+        String taskLines = IntStream.range(0, tasks.size())
+                .mapToObj(i -> (i + 1) + "." + tasks.get(i).toString() + "\n")
+                .collect(Collectors.joining());
+        return "Here are your searched Epstein files:\n" + taskLines;
     }
 }


### PR DESCRIPTION
Several methods in TaskList, Ui, and Storage use explicit for-loops to iterate over task collections and build string results.

Explicit for-loops are more verbose and imperative, making the intent of each operation harder to read at a glance.

Let's,
* replace the for-loop in TaskList.findTask() with a stream filter
* replace the for-loops in Ui.showTaskList() and Ui.showFindResults() with IntStream.range() and Collectors.joining()
* replace the for-loop in Storage.saveTask() with a stream map and Collectors.joining()

Streams express the intent of each operation more declaratively, making the code easier to read and reason about.